### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generator-generic-ossf-slsa3-publish.yml
+++ b/.github/workflows/generator-generic-ossf-slsa3-publish.yml
@@ -19,6 +19,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       digests: ${{ steps.hash.outputs.digests }}
 


### PR DESCRIPTION
Potential fix for [https://github.com/nibertinvestments/WEB3/security/code-scanning/1](https://github.com/nibertinvestments/WEB3/security/code-scanning/1)

To fix the problem, add an explicit `permissions` block for the `build` job in the workflow file `.github/workflows/generator-generic-ossf-slsa3-publish.yml`. The minimal recommended permissions are `contents: read`, which will allow read-only access to the repository contents and prevent unnecessary write access. This should be added directly under the `build:` job definition, parallel to `runs-on`, before listing outputs/steps. No other code or logic changes are necessary; simply include the permissions block.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
